### PR TITLE
Add Teams chatbot integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,22 @@
 # NewsTagging
+
+## Chatbot with Microsoft Teams
+
+This project now includes a simple chatbot interface that forwards user
+messages to a Microsoft Teams channel. Developers can reply from Teams and
+their responses will appear in the chatbot UI.
+
+### Configuration
+
+1. Create an **Incoming Webhook** in Microsoft Teams and copy the provided
+   URL.
+2. Optionally create an **Outgoing Webhook** in Teams pointing to
+   `/chatbot/teams` on this application to send developer replies back to the
+   chatbot.
+3. Set the environment variable `TEAMS_WEBHOOK_URL` with the incoming webhook
+   URL.
+
+### Usage
+
+Start the Flask application and visit `/chatbot` to interact with the chat
+interface.

--- a/main.py
+++ b/main.py
@@ -45,6 +45,7 @@ app.register_blueprint(projects_bp, url_prefix='/api/projects')
 app.register_blueprint(pdf_bp, url_prefix='/')
 app.register_blueprint(reports_bp, url_prefix='/')
 app.register_blueprint(analytics_bp, url_prefix='/')
+app.register_blueprint(chatbot_bp, url_prefix='/chatbot')
 
 # CORS(app, origins=["http://qa.platformxplus.com:5000"])
 

--- a/routes/chatbot_routes.py
+++ b/routes/chatbot_routes.py
@@ -1,0 +1,50 @@
+import os
+import requests
+from flask import Blueprint, request, jsonify, render_template
+
+chatbot_bp = Blueprint('chatbot', __name__)
+
+# In-memory store for messages. In production, use persistent storage.
+MESSAGES = []
+
+@chatbot_bp.route('/', methods=['GET'])
+def chatbot_home():
+    """Render simple chatbot page."""
+    return render_template('chatbot.html')
+
+@chatbot_bp.route('/message', methods=['POST'])
+def handle_message():
+    """Receive a message from the user and forward to Microsoft Teams."""
+    data = request.get_json() or {}
+    text = data.get('text', '').strip()
+    user = data.get('user', 'User')
+    if not text:
+        return jsonify({'success': False, 'message': 'Message text required'}), 400
+
+    MESSAGES.append({'sender': user, 'text': text})
+
+    webhook_url = os.getenv('TEAMS_WEBHOOK_URL')
+    if webhook_url:
+        payload = {'text': f"{user}: {text}"}
+        try:
+            requests.post(webhook_url, json=payload, timeout=5)
+        except Exception:
+            # If Teams webhook fails, still return success to user
+            pass
+
+    return jsonify({'success': True})
+
+@chatbot_bp.route('/teams', methods=['POST'])
+def teams_webhook():
+    """Endpoint for Microsoft Teams outgoing webhook to post replies."""
+    data = request.json or {}
+    text = data.get('text', '').strip()
+    if text:
+        MESSAGES.append({'sender': 'Developer', 'text': text})
+    # Teams expects a JSON response describing the message that will appear in the channel
+    return jsonify({'type': 'message', 'text': 'Message received'})
+
+@chatbot_bp.route('/messages', methods=['GET'])
+def get_messages():
+    """Return all chat messages."""
+    return jsonify(MESSAGES)

--- a/templates/chatbot.html
+++ b/templates/chatbot.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8" />
+    <title>Chatbot</title>
+    <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+</head>
+<body>
+<h2>Support Chat</h2>
+<div id="messages" style="border:1px solid #ccc;height:300px;overflow-y:scroll;padding:5px;margin-bottom:10px;"></div>
+<input type="text" id="message" placeholder="Type your question" style="width:80%;"/>
+<button id="send">Send</button>
+
+<script>
+function loadMessages(){
+    $.getJSON('/chatbot/messages', function(data){
+        var msgs = $('#messages');
+        msgs.empty();
+        data.forEach(function(m){
+            msgs.append('<div><strong>'+m.sender+':</strong> '+m.text+'</div>');
+        });
+        msgs.scrollTop(msgs[0].scrollHeight);
+    });
+}
+$('#send').on('click', function(){
+    var text = $('#message').val();
+    $.ajax({
+        url:'/chatbot/message',
+        method:'POST',
+        contentType:'application/json',
+        data: JSON.stringify({text:text}),
+        success:function(){
+            $('#message').val('');
+            loadMessages();
+        }
+    });
+});
+setInterval(loadMessages,3000);
+loadMessages();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add Microsoft Teams chatbot routes and UI to forward user messages and receive developer replies
- register chatbot blueprint and document configuration

## Testing
- `python -m py_compile routes/chatbot_routes.py main.py`


------
https://chatgpt.com/codex/tasks/task_e_6892fc5be4f0832f944147f8da80c1e6