### PR TITLE
Enable Socket.IO-based Teams chatbot communication

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 ## Chatbot with Microsoft Teams
 
-This project now includes a simple chatbot interface that forwards user
-messages to a Microsoft Teams channel. Developers can reply from Teams and
-their responses will appear in the chatbot UI.
+This project now includes a real-time chatbot interface powered by Socket.IO
+that forwards user messages to a Microsoft Teams channel. Developers can reply
+from Teams and their responses will instantly appear in the chatbot UI.
 
 ### Configuration
 

--- a/main.py
+++ b/main.py
@@ -11,7 +11,7 @@ from routes.pdf_routes import pdf_bp
 from routes.manage_reports_routes import reports_bp
 from routes.document_routes import document_bp
 from routes.analytics_routes import analytics_bp
-from routes.chatbot_routes import chatbot_bp
+from routes.chatbot_routes import chatbot_bp, socketio
 import secrets
 from xhtml2pdf import pisa
 from pdf2docx import Converter
@@ -46,6 +46,7 @@ app.register_blueprint(pdf_bp, url_prefix='/')
 app.register_blueprint(reports_bp, url_prefix='/')
 app.register_blueprint(analytics_bp, url_prefix='/')
 app.register_blueprint(chatbot_bp, url_prefix='/chatbot')
+socketio.init_app(app)
 
 # CORS(app, origins=["http://qa.platformxplus.com:5000"])
 
@@ -2977,4 +2978,4 @@ def internal_server_error(e):
 if __name__ == '__main__':
     # from waitress import serve  # Recommended for Windows
     # serve(app, host="0.0.0.0", port=5000, threads=16)
-    app.run(debug=True)
+    socketio.run(app, debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ xhtml2pdf
 pyaudio
 waitress
 dotenv
+flask-socketio

--- a/templates/chatbot.html
+++ b/templates/chatbot.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8" />
     <title>Chatbot</title>
     <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+    <script src="https://cdn.socket.io/4.7.2/socket.io.min.js" integrity="sha384-wfVd4G7yzTf/3GQ8LNk31DJ7tY79DbDeihdj5Z8SGvtQvECOH14R/2uOeGjn5ERa" crossorigin="anonymous"></script>
 </head>
 <body>
 <h2>Support Chat</h2>
@@ -12,31 +13,28 @@
 <button id="send">Send</button>
 
 <script>
-function loadMessages(){
-    $.getJSON('/chatbot/messages', function(data){
-        var msgs = $('#messages');
-        msgs.empty();
-        data.forEach(function(m){
-            msgs.append('<div><strong>'+m.sender+':</strong> '+m.text+'</div>');
-        });
-        msgs.scrollTop(msgs[0].scrollHeight);
-    });
+const socket = io();
+const msgs = $('#messages');
+
+function appendMessage(m){
+    msgs.append('<div><strong>'+m.sender+':</strong> '+m.text+'</div>');
+    msgs.scrollTop(msgs[0].scrollHeight);
 }
+
+socket.on('init_messages', function(data){
+    msgs.empty();
+    data.forEach(appendMessage);
+});
+
+socket.on('new_message', function(m){
+    appendMessage(m);
+});
+
 $('#send').on('click', function(){
     var text = $('#message').val();
-    $.ajax({
-        url:'/chatbot/message',
-        method:'POST',
-        contentType:'application/json',
-        data: JSON.stringify({text:text}),
-        success:function(){
-            $('#message').val('');
-            loadMessages();
-        }
-    });
+    socket.emit('send_message', {text:text});
+    $('#message').val('');
 });
-setInterval(loadMessages,3000);
-loadMessages();
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Replace polling chatbot with real-time Socket.IO chat that forwards messages to Microsoft Teams
- Broadcast developer replies from Teams to all connected chatbot clients
- Update README and dependencies for Socket.IO setup

## Testing
- `python -m py_compile main.py routes/chatbot_routes.py`


------
https://chatgpt.com/codex/tasks/task_e_6893515f837c832fac8697bc20793a8a