### PR TITLE
Replace dotenv with python-dotenv

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 pandas
 flask
-django
 requests
 pymongo
 pytz
@@ -9,5 +8,5 @@ boto3
 xhtml2pdf
 pyaudio
 waitress
-dotenv
+python-dotenv
 flask-socketio


### PR DESCRIPTION
## Summary
- replace deprecated `dotenv` dependency with `python-dotenv`
- drop unused `django` requirement

## Testing
- `pip install -r requirements.txt`
- `python main.py` *(fails: ModuleNotFoundError: No module named 'routes.tracking')*

------
https://chatgpt.com/codex/tasks/task_e_689450b9aaec832f8993d31afcb0f549