### PR TITLE
Replace chatbot with Teams-integrated popup

### DIFF
--- a/main.py
+++ b/main.py
@@ -11,7 +11,7 @@ from routes.pdf_routes import pdf_bp
 from routes.manage_reports_routes import reports_bp
 from routes.document_routes import document_bp
 from routes.analytics_routes import analytics_bp
-from routes.chatbot_routes import chatbot_bp, socketio
+from routes.chatbot_routes import chatbot_bp
 import secrets
 from xhtml2pdf import pisa
 from pdf2docx import Converter
@@ -46,7 +46,6 @@ app.register_blueprint(pdf_bp, url_prefix='/')
 app.register_blueprint(reports_bp, url_prefix='/')
 app.register_blueprint(analytics_bp, url_prefix='/')
 app.register_blueprint(chatbot_bp, url_prefix='/chatbot')
-socketio.init_app(app)
 
 # CORS(app, origins=["http://qa.platformxplus.com:5000"])
 
@@ -2978,4 +2977,4 @@ def internal_server_error(e):
 if __name__ == '__main__':
     # from waitress import serve  # Recommended for Windows
     # serve(app, host="0.0.0.0", port=5000, threads=16)
-    socketio.run(app, debug=True)
+    app.run(debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,3 @@ xhtml2pdf
 pyaudio
 waitress
 python-dotenv
-flask-socketio

--- a/templates/chatbot.html
+++ b/templates/chatbot.html
@@ -2,39 +2,107 @@
 <html>
 <head>
     <meta charset="utf-8" />
-    <title>Chatbot</title>
-    <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
-    <script src="https://cdn.socket.io/4.7.2/socket.io.min.js" integrity="sha384-wfVd4G7yzTf/3GQ8LNk31DJ7tY79DbDeihdj5Z8SGvtQvECOH14R/2uOeGjn5ERa" crossorigin="anonymous"></script>
+    <title>Teams Chatbot</title>
+    <style>
+        #chatbot-container {
+            position: fixed;
+            bottom: 20px;
+            right: 20px;
+            width: 300px;
+            font-family: Arial, sans-serif;
+            border: 1px solid #ccc;
+            border-radius: 10px;
+            background: #fff;
+            box-shadow: 0 0 10px rgba(0,0,0,0.1);
+            overflow: hidden;
+        }
+        #chatbot-header {
+            background: #0078d4;
+            color: #fff;
+            padding: 10px;
+            cursor: pointer;
+        }
+        #chatbot-body {
+            display: none;
+        }
+        #chatbot-messages {
+            height: 200px;
+            overflow-y: auto;
+            padding: 10px;
+        }
+        #chatbot-input {
+            display: flex;
+            border-top: 1px solid #ccc;
+        }
+        #chatbot-input input {
+            flex: 1;
+            border: none;
+            padding: 10px;
+        }
+        #chatbot-input button {
+            border: none;
+            background: #0078d4;
+            color: #fff;
+            padding: 10px 15px;
+            cursor: pointer;
+        }
+    </style>
 </head>
 <body>
-<h2>Support Chat</h2>
-<div id="messages" style="border:1px solid #ccc;height:300px;overflow-y:scroll;padding:5px;margin-bottom:10px;"></div>
-<input type="text" id="message" placeholder="Type your question" style="width:80%;"/>
-<button id="send">Send</button>
-
+<div id="chatbot-container">
+    <div id="chatbot-header">Chatbot</div>
+    <div id="chatbot-body">
+        <div id="chatbot-messages"></div>
+        <div id="chatbot-input">
+            <input type="text" id="message" placeholder="Type a message" />
+            <button id="send">Send</button>
+        </div>
+    </div>
+</div>
 <script>
-const socket = io();
-const msgs = $('#messages');
+const header = document.getElementById('chatbot-header');
+const body = document.getElementById('chatbot-body');
+const messagesEl = document.getElementById('chatbot-messages');
+const sendBtn = document.getElementById('send');
+const inputEl = document.getElementById('message');
+let username = localStorage.getItem('chatbot_user') || ('User_' + Math.floor(Math.random()*1000));
+localStorage.setItem('chatbot_user', username);
 
-function appendMessage(m){
-    msgs.append('<div><strong>'+m.sender+':</strong> '+m.text+'</div>');
-    msgs.scrollTop(msgs[0].scrollHeight);
+function toggleBody(){
+    body.style.display = body.style.display === 'none' ? 'block' : 'none';
 }
 
-socket.on('init_messages', function(data){
-    msgs.empty();
-    data.forEach(appendMessage);
-});
+function appendMessage(m){
+    const div = document.createElement('div');
+    div.innerHTML = '<strong>' + m.sender + ':</strong> ' + m.text;
+    messagesEl.appendChild(div);
+    messagesEl.scrollTop = messagesEl.scrollHeight;
+}
 
-socket.on('new_message', function(m){
-    appendMessage(m);
-});
+function poll(){
+    fetch('/chatbot/poll')
+        .then(r => r.json())
+        .then(data => {
+            messagesEl.innerHTML = '';
+            data.forEach(appendMessage);
+        });
+}
 
-$('#send').on('click', function(){
-    var text = $('#message').val();
-    socket.emit('send_message', {text:text});
-    $('#message').val('');
-});
+function send(){
+    const text = inputEl.value.trim();
+    if(!text) return;
+    fetch('/chatbot/send', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({text: text, user: username})
+    }).then(() => { inputEl.value=''; poll(); });
+}
+
+header.addEventListener('click', toggleBody);
+sendBtn.addEventListener('click', send);
+inputEl.addEventListener('keydown', e => { if(e.key==='Enter') send(); });
+setInterval(poll, 5000);
+
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- remove legacy Socket.IO chatbot
- add Teams webhook + Graph API routes for send/poll
- style popup chatbot widget
- drop `flask-socketio` dependency

## Testing
- `python -m py_compile main.py routes/chatbot_routes.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6894636a6a94832f8b3c8df04c55e5a6