### PR TITLE
Load responsive stylesheet after custom theme

### DIFF
--- a/templates/Dashboardv2.html
+++ b/templates/Dashboardv2.html
@@ -29,6 +29,7 @@
 
     <!-- Custom Theme Style -->
     <link href="../static/css/custom.min.css" rel="stylesheet">
+    <link href="../static/css/responsive.css" rel="stylesheet">
     <script src="https://cdn.jsdelivr.net/npm/echarts@5.4.2/dist/echarts.min.js"></script>
 
 <!--    <script type="text/javascript" src="https://cdn.jsdelivr.net/jquery/latest/jquery.min.js"></script>-->

--- a/templates/Newsv2.html
+++ b/templates/Newsv2.html
@@ -22,6 +22,7 @@
     
         <!-- Custom styling plus plugins -->
     <link href="./static/css/custom.min.css" rel="stylesheet">
+    <link href="./static/css/responsive.css" rel="stylesheet">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons/font/bootstrap-icons.css">
     <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/npm/daterangepicker/daterangepicker.css" />
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">

--- a/templates/Register.html
+++ b/templates/Register.html
@@ -22,6 +22,7 @@
     <!-- Custom Theme Style -->
     <link href="../static/css/custom.min.css" rel="stylesheet">
     <link href="../static/build/css/custom.min.css" rel="stylesheet">
+    <link href="../static/css/responsive.css" rel="stylesheet">
     <style>
       .logo {
       color: #1877f2;

--- a/templates/Report-Management.html
+++ b/templates/Report-Management.html
@@ -29,6 +29,7 @@
 
     <!-- Custom Theme Style -->
     <link href="./static/css/custom.min.css" rel="stylesheet">
+    <link href="./static/css/responsive.css" rel="stylesheet">
     <script src="https://cdn.jsdelivr.net/npm/echarts@5.4.2/dist/echarts.min.js"></script>
 <!--      <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>-->
 

--- a/templates/SocialMediav2.html
+++ b/templates/SocialMediav2.html
@@ -13,6 +13,7 @@
   <link rel="stylesheet" href="{{ url_for('static', filename='css/nprogress.css') }}">
   <link rel="stylesheet" href="{{ url_for('static', filename='css/prettify.min.css') }}">
   <link rel="stylesheet" href="{{ url_for('static', filename='css/custom.min.css') }}">
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/responsive.css') }}">
   <link rel="stylesheet" href="{{ url_for('static', filename='css/styles-popup.css') }}">
 
   <!-- External Libraries -->
@@ -29,9 +30,10 @@
 <link href="./static/css/prettify.min.css" rel="stylesheet">
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css">
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
- 
+
     <!-- Custom styling plus plugins -->
 <link href="./static/css/custom.min.css" rel="stylesheet">
+<link href="./static/css/responsive.css" rel="stylesheet">
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons/font/bootstrap-icons.css">
 <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/npm/daterangepicker/daterangepicker.css" />
 <link rel="stylesheet" href="../static/css/styles-popup.css">

--- a/templates/add-card.html
+++ b/templates/add-card.html
@@ -28,6 +28,7 @@
 
     <!-- Custom Theme Style -->
     <link href="./static/css/custom.min.css" rel="stylesheet">
+    <link href="./static/css/responsive.css" rel="stylesheet">
     <script src="https://cdn.jsdelivr.net/npm/echarts@5.4.2/dist/echarts.min.js"></script>
 <!--      <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>-->
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -27,6 +27,7 @@
 <link href="../static/vendors/bootstrap-daterangepicker/daterangepicker.css" rel="stylesheet">
 <!-- Custom Theme Style -->
 <link href="../static/css/custom.min.css" rel="stylesheet"/>
+<link href="../static/css/responsive.css" rel="stylesheet"/>
 <script src="https://cdn.jsdelivr.net/npm/echarts@5.4.2/dist/echarts.min.js"></script>
 <!--    <script type="text/javascript" src="https://cdn.jsdelivr.net/jquery/latest/jquery.min.js"></script>-->
 <!-- Add these to your head section -->

--- a/templates/page_403.html
+++ b/templates/page_403.html
@@ -18,6 +18,7 @@
 
     <!-- Custom Theme Style -->
     <link href="../static/build/css/custom.min.css" rel="stylesheet">
+    <link href="../static/css/responsive.css" rel="stylesheet">
   </head>
 
   <body class="nav-md">

--- a/templates/page_404.html
+++ b/templates/page_404.html
@@ -18,6 +18,7 @@
 
     <!-- Custom Theme Style -->
     <link href="../build/css/custom.min.css" rel="stylesheet">
+    <link href="../static/css/responsive.css" rel="stylesheet">
   </head>
 
   <body class="nav-md">

--- a/templates/page_500.html
+++ b/templates/page_500.html
@@ -18,6 +18,7 @@
 
     <!-- Custom Theme Style -->
     <link href="../build/css/custom.min.css" rel="stylesheet">
+    <link href="../static/css/responsive.css" rel="stylesheet">
   </head>
 
   <body class="nav-md">

--- a/templates/projects.html
+++ b/templates/projects.html
@@ -21,6 +21,7 @@
     
         <!-- Custom styling plus plugins -->
     <link href="./static/css/custom.min.css" rel="stylesheet">
+    <link href="./static/css/responsive.css" rel="stylesheet">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons/font/bootstrap-icons.css">
     <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/npm/daterangepicker/daterangepicker.css" />
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">


### PR DESCRIPTION
## Summary
- add the responsive.css bundle after each custom.min.css include in the HTML templates so overrides win the cascade
- update SocialMediav2 to load the responsive sheet for both the Jinja-served and static fallback asset paths

## Testing
- ⚠️ `pip install -r requirements.txt` *(fails: cairo development package missing for pycairo)*
- ✅ `python -m http.server 8000` *(manually verified responsive layout via Playwright screenshot)*

------
https://chatgpt.com/codex/tasks/task_e_68dbcec5875c832f9c578fab38d83a3c